### PR TITLE
Fix CVE-2024-43688: buffer underflow for very large step values

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+cron (3.0pl1-162deepin1) unstable; urgency=high
+
+  * Fix CVE-2024-43688: buffer underflow for very large step values.
+    In get_number(), reject values that are so large that they are
+    interpreted as negative numbers. This prevents bit_nset() from
+    being called with out-of-range values when processing crontab
+    entries with malicious step values.
+
+ -- hudeng <hudeng@deepin.org>  Wed, 26 Feb 2026 10:00:00 +0800
+
 cron (3.0pl1-162) unstable; urgency=medium
 
   * moved "Breaks: systemd-cron(<<1.15.19-5~)" to the package

--- a/debian/patches/CVE/CVE-2024-43688.patch
+++ b/debian/patches/CVE/CVE-2024-43688.patch
@@ -1,0 +1,31 @@
+From: hudeng <hudeng@deepin.org>
+Date: Wed, 26 Feb 2026 10:00:00 +0800
+Subject: Fix CVE-2024-43688: buffer underflow for very large step values
+
+In get_number(), reject values that are so large that they are
+interpreted as negative numbers. This prevents bit_nset() from
+being called with out-of-range values when processing crontab
+entries with malicious step values.
+
+Bug found by Dave G. of Supernetworks.
+
+CVE: CVE-2024-43688
+Origin: upstream, https://github.com/vixie/cron/commit/9cc8ab1087bb9ab861dd5595c41200683c9f6712
+Forwarded: not-needed
+Last-Update: 2026-02-26
+
+Index: cron/entry.c
+===================================================================
+--- cron.orig/entry.c
++++ cron/entry.c
+@@ -480,7 +480,10 @@ get_number(numptr, low, names, ch, file
+ 	 * otherwise, it's an error.
+ 	 */
+ 	if (all_digits) {
+-		*numptr = atoi(temp);
++		i = atoi(temp);
++		if (i < 0)
++			return EOF;
++		*numptr = i;
+ 		return ch;
+ 	}

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -74,3 +74,4 @@ fixes/Check_for_timezone_changes.patch
 features/No-multiple-timezones.patch
 fixes/crontab_5_manpage.patch
 features/dry-run.patch
+CVE/CVE-2024-43688.patch


### PR DESCRIPTION
In get_number(), reject values that are so large that they are interpreted as negative numbers. This prevents bit_nset() from being called with out-of-range values when processing crontab entries with malicious step values.

Bug found by Dave G. of Supernetworks.

CVE: CVE-2024-43688
Origin: upstream, https://github.com/vixie/cron/commit/9cc8ab1087bb9ab861dd5595c41200683c9f6712